### PR TITLE
fix-race-condition

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -3,3 +3,6 @@
       - wazo-tox-linters-310
       - wazo-tox-py39
       - debian-packaging-bullseye
+    experimental:
+      jobs:
+        - wazo-acceptance-bullseye


### PR DESCRIPTION
Traceback:
WS encountered an error: AttributeError: 'NoneType' object has no
attribute 'is_ssl'

Calling "close()" from the main thread while "run_forever()" runs in another
thread can set self.sock to None. In rare cases, such as slow/issue connection
setup, "close()" may be called before the dispatcher is created, causing it
to fail assuming "self.sock" is always set.

The function has been rewritten in 1.4.0 and should fix this traceback
