### PR TITLE
pre-commit: bump mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: wazo-copyright-check
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: "3.11"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates typing checks used by pre-commit.
> 
> - Bumps `mypy` hook in `.pre-commit-config.yaml` from `v0.991` to `v1.19.1`
> - Keeps `language_version: "3.11"` and `additional_dependencies: ["types-requests"]` unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f2f034ddd5d1debc06c2d8ac5c37169c46e469b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->